### PR TITLE
Closing Time was Set Before Midnight

### DIFF
--- a/api/chair/setParameters.py
+++ b/api/chair/setParameters.py
@@ -14,29 +14,29 @@ def setParameters_GET ():
     openDate = datetime.datetime.strptime(data['applicationOpenDate'], '%Y-%m-%d')
     closeDate = (datetime.datetime
                          .strptime(data['applicationCloseDate'], '%Y-%m-%d')
-                         .replace(hour=11, minute=55) )
+                         .replace(hour=23, minute=55) )
     parameters = Parameters(year = int(data['newYear']),
                             appOpenDate = openDate,
                             appCloseDate =closeDate,
                             mileageRate = data['mileageRate'],
                             laborRate = data['laborRate'])
-    
+
     parameters.save()
-    
+
     flash('New application year succesfully created')
     return redirect(url_for('setParameters_GET', username = g.user.username))
-    
+
   parameters = getCurrentParameters()
   parameters_list = Parameters.select().order_by(-Parameters.year)
-  
-  return render_template ("chair/setParameters.html", 
+
+  return render_template ("chair/setParameters.html",
                            username = g.user.username,
                            ldap = g.user,
                            params = parameters,
                            parameters_list = parameters_list,
                            cfg = cfg,
                            )
-                           
+
 @app.route("/delete/parameters/<pID>", methods=['GET'])
 @login_required
 def deleteParameters(pID):
@@ -45,9 +45,7 @@ def deleteParameters(pID):
   try:
     parameters = Parameters.get(Parameters.pID == pID)
     parameters.delete_instance()
-  
+
   except Parameters.DoesNotExist:
     flash('Parameters not found')
   return redirect(redirect_url())
-  
-  

--- a/api/chair/setParameters.py
+++ b/api/chair/setParameters.py
@@ -14,7 +14,7 @@ def setParameters_GET ():
     openDate = datetime.datetime.strptime(data['applicationOpenDate'], '%Y-%m-%d')
     closeDate = (datetime.datetime
                          .strptime(data['applicationCloseDate'], '%Y-%m-%d')
-                         .replace(hour=23, minute=55) )
+                         .replace(hour=23, minute=59) )
     parameters = Parameters(year = int(data['newYear']),
                             appOpenDate = openDate,
                             appCloseDate =closeDate,


### PR DESCRIPTION
This PR fixes issue #176 where the closing time was not set to midnight on the closing date.

Fix: Change the code that sets the time of the end date to 23:59 instead of 11:55 because we are working in a 24hr format time.


