### PR TITLE
Improving the Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,16 +5,15 @@ FROM python:2.7
 
 MAINTAINER Brian Ramsay "ramsayb2@berea.edu"
 
+ENV PYTHONUNBUFFERED 1
+
+RUN pip install --upgrade pip
+
+COPY requirements.txt /tmp/pip-tmp/
+
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && rm -rf /tmp/pip-tmp
+
+RUN bash -c "./setup.sh"
+
 EXPOSE 8080
-
-COPY ./requirements.txt /requirements.txt
-
-WORKDIR /
-
-RUN pip install -r requirements.txt
-
-COPY . /
-
-RUN ["/bin/bash","-c","./setup.sh"]
-
-ENTRYPOINT [ "python", "api.py" ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,19 +1,13 @@
 # The first instruction is what image we want to base our container on
-# We Use an official Python runtime as a parent image
-# TODO  https://perchrunway.com/blog/2017-01-19-getting-started-with-docker-for-local-development
-FROM python:2.7
+FROM mcr.microsoft.com/devcontainers/python:0-3.11
 
-MAINTAINER Brian Ramsay "ramsayb2@berea.edu"
+LABEL maintainer="Brian Ramsay 'ramsayb2@berea.edu'"
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 RUN pip install --upgrade pip
 
-COPY requirements.txt /tmp/pip-tmp/
-
-RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
-    && rm -rf /tmp/pip-tmp
-
-RUN bash -c "./setup.sh"
+# Run source setup.sh whenever a bash terminal is opened in vscode (setup.sh is also run after volumes are mounted as the entrypoint in docker-compose)
+RUN echo "source setup.sh > /dev/null" > /home/vscode/.bashrc
 
 EXPOSE 8080

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+    "name": "Python3, Flask, and MySQL Dev Container",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+
+    "workspaceFolder": "/home/vscode/${localWorkspaceFolderBasename}",
+    "remoteUser": "vscode",
+
+    "forwardPorts": [5000,3307],
+    
+    "remoteEnv": {
+        "FLASK_DEBUG": "1",
+        "APP_ENV": "development",
+        "USING_CONTAINER": "1",
+        "MYSQL_HOST": "db",
+        "MYSQL_PWD": "password"
+    },
+    
+    "postCreateCommand": "mysql -u celts_user -e \"SELECT * from celts.user\" > /dev/null 2>&1  || database/reset_database.sh test"
+
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,16 +6,16 @@
     "workspaceFolder": "/home/vscode/${localWorkspaceFolderBasename}",
     "remoteUser": "vscode",
 
-    "forwardPorts": [5000,3307],
+    "forwardPorts": [8080,3306],
     
     "remoteEnv": {
         "FLASK_DEBUG": "1",
         "APP_ENV": "development",
         "USING_CONTAINER": "1",
         "MYSQL_HOST": "db",
-        "MYSQL_PWD": "password"
+        "MYSQL_PWD": "DanforthLabor123!"
     },
     
-    "postCreateCommand": "mysql -u celts_user -e \"SELECT * from celts.user\" > /dev/null 2>&1  || database/reset_database.sh test"
+    "postCreateCommand": "/home/vscode/urcpp/setup.sh"
 
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,6 +7,10 @@ services:
         dockerfile: .devcontainer/Dockerfile
     volumes:
       - ..:/home/vscode/urcpp
+    
+    entrypoint: ["/home/vscode/urcpp/entrypoint.sh"]
+    command: sleep infinity
+
     links:
       - db
     ports:
@@ -24,5 +28,5 @@ services:
         # Password for root access
         MYSQL_ROOT_PASSWORD: 'root'
       volumes:
-        - ./docker/data/db:/var/lib/mysql
-        - ./database/docker_init:/docker-entrypoint-initdb.d
+        - ../docker/data/db:/var/lib/mysql
+        - ../database/docker_init:/docker-entrypoint-initdb.d

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,10 @@ version: "3.7"
 services:
   app:
     build: 
-        context: .
+        context: ..
+        dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/home/vscode/urcpp
     links:
       - db
     ports:
@@ -13,13 +16,13 @@ services:
       ports:
         - "3306:3306"
       environment:
-        MYSQL_DATABASE: 'urcpp_flask'
+        MYSQL_DATABASE: 'urcpp'
         # So you don't have to use root, but you can if you like
-        MYSQL_USER: 'urcpp-flask'
+        MYSQL_USER: 'urcpp_flask'
         # You can use whatever password you like
         MYSQL_PASSWORD: 'DanforthLabor123!'
         # Password for root access
-        MYSQL_ROOT_PASSWORD: 'password'
+        MYSQL_ROOT_PASSWORD: 'root'
       volumes:
         - ./docker/data/db:/var/lib/mysql
         - ./database/docker_init:/docker-entrypoint-initdb.d

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -3,10 +3,10 @@ DEBUG:
   user: "jadudm"
 
 db:
-  host: "localhost"
-  name: "urcpp_flask"
-  user: "urcpp_flask"
-  password: "DanforthLabor123!"
+  name: "urcpp"
+  host: "db"
+  user: "root"
+  password: "root"
 
 urcpp:
   possibleDurations:
@@ -146,6 +146,9 @@ contributors:
   - name: "Luis Jesus Riera Soto"
     username: "rieral"
     year: 2022
+  - name: "Lawrence Hoerst"
+    username: ""
+    year: 2025
 
 # Controls the menu for the committee interfaces
 committee:

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -5,8 +5,8 @@ DEBUG:
 db:
   name: "urcpp"
   host: "db"
-  user: "root"
-  password: "root"
+  user: "urcpp_flask"
+  password: "DanforthLabor123!"
 
 urcpp:
   possibleDurations:

--- a/api/models.py
+++ b/api/models.py
@@ -10,11 +10,11 @@ cfg = load_config(os.path.join(here, 'config.yaml'))
 
 
 
-print cfg['db']['name'] # Beans
-print cfg['db']['host'] # Beans
-print cfg['db']['user'] # Beans
-print cfg['db']['password'] # Beans
-print '*'*1000
+print (cfg['db']['name']) # Beans
+print (cfg['db']['host']) # Beans
+print (cfg['db']['user']) # Beans
+print (cfg['db']['password']) # Beans
+print ('*'*1000)
 dynamicDB = MySQLDatabase(cfg['db']['name'], host=cfg['db']['host'], user=cfg['db']['user'], passwd=cfg['db']['password'])
 
 class DynamicModel (Model):

--- a/api/models.py
+++ b/api/models.py
@@ -8,13 +8,6 @@ here = os.path.dirname(__file__)
 
 cfg = load_config(os.path.join(here, 'config.yaml'))
 
-
-
-print (cfg['db']['name']) # Beans
-print (cfg['db']['host']) # Beans
-print (cfg['db']['user']) # Beans
-print (cfg['db']['password']) # Beans
-print ('*'*1000)
 dynamicDB = MySQLDatabase(cfg['db']['name'], host=cfg['db']['host'], user=cfg['db']['user'], passwd=cfg['db']['password'])
 
 class DynamicModel (Model):

--- a/api/models.py
+++ b/api/models.py
@@ -8,6 +8,13 @@ here = os.path.dirname(__file__)
 
 cfg = load_config(os.path.join(here, 'config.yaml'))
 
+
+
+print cfg['db']['name'] # Beans
+print cfg['db']['host'] # Beans
+print cfg['db']['user'] # Beans
+print cfg['db']['password'] # Beans
+print '*'*1000
 dynamicDB = MySQLDatabase(cfg['db']['name'], host=cfg['db']['host'], user=cfg['db']['user'], passwd=cfg['db']['password'])
 
 class DynamicModel (Model):

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Wait for the volume to be mounted
+while [ ! -f /home/vscode/urcpp/setup.sh ]; do
+    echo "Waiting for volume to be mounted..."
+    sleep 1
+done
+
+# Run the desired command
+cd /home/vscode/urcpp || { echo "Directory for project not found! Exiting."; exit 1; }
+./setup.sh
+exec "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -6,11 +6,12 @@
 
 if [ ! -d venv ]
 then
-  virtualenv venv
+  python3 -m venv venv
 fi
 
 . venv/bin/activate
 
+pip install --upgrade pip
 pip install -r requirements.txt
 
 # TODO create a db script that can use the docker init builder


### PR DESCRIPTION
## Issue
Resolves issue #191 

Unable to run the app development environment in current state.

URCPP is currently not runnable using the docker container and docker-compose file with myriad of permission issues on the database and inconsistencies between the usernames and passwords being used to make the DB connection.

The repository should be modified to use a .devcontainer folder which sets up the development environment on its own.

Additional changes should address:
- Move the Dockerfile and docker-compose.yml files to a .devcontainer folder so we can develop in any environment.
- Storing the code in a volume so we don't need to rebuild every time to copy changed files into our docker image.
- Fixing permission issues between the database and the app containers. (The app currently doesn't run due to permission issues)
- Migrating to Python 3 (Scott Heggen made the migration to python 3 using local setup in [this PR](https://github.com/BCStudentSoftwareDevTeam/urcpp/pull/190)) within the docker container.



## Changes

TBD

## To Test

TBD
