### PR TITLE
Fixing presentation of proposal due time

### DIFF
--- a/api/chair/setParameters.py
+++ b/api/chair/setParameters.py
@@ -14,7 +14,7 @@ def setParameters_GET ():
     openDate = datetime.datetime.strptime(data['applicationOpenDate'], dateFormat)
     closeDate = (datetime.datetime
                          .strptime(data['applicationCloseDate'], dateFormat)
-                         .replace(hour=11, minute=55) )
+                         .replace(hour=23, minute=59) )
 #    ProposalOpenDate = datetime.datetime.strptime(data['ProposalOpenDate'], dateFormat)
     ProposalAcceptanceDate = datetime.datetime.strptime(data['ProposalAcceptanceDate'], dateFormat)
 #    ProposalClosedDate = ( datetime.datetime.strptime(data['ProposalClosedDate'], dateFormat).replace(hour=11, minute=55) )
@@ -22,7 +22,7 @@ def setParameters_GET ():
  #   AbstractnarrativesAcceptanceDate = ( datetime.datetime.strptime(data['AbstractnarrativesAcceptanceDate'], dateFormat).replace(hour=11, minute=55) )
 
     AllSubmissionsClosedDate = ( datetime.datetime.strptime(data['AllSubmissionsClosedDate'], dateFormat)
-						  .replace(hour=11, minute=55) )
+						  .replace(hour=23, minute=59) )
 
  
     

--- a/api/templates/snips/horizontalProgressBar.html
+++ b/api/templates/snips/horizontalProgressBar.html
@@ -23,7 +23,7 @@
             </div>
             <div class="point" id="pending">
                 <div class="bullet"></div>
-                <label class="bar-label" style="text-align: center">Proposals Due: <br><small style="font-size:12px;" "text-align: center;">{{currentCycle.appCloseDate.strftime("%m/%d/%Y")}}</small></label>
+                <label class="bar-label" style="text-align: center">Proposals Due: <br><small style="font-size:12px;" "text-align: center;">{{currentCycle.appCloseDate.strftime("%m/%d/%Y")}} by 11:59PM</small></label>
             </div>
 {#            <div class="point" id="pending">
                 <div class="bullet"></div>
@@ -39,7 +39,7 @@
             </div> #}
             <div class="point" id="abstract_submission">
                 <div class="bullet"></div>
-                <label class="bar-label" style="text-align: center">Abstracts Due:<br><small style="font-size:12px;" "text-align: center;">{{currentCycle.AllSubmissionsClosedDate.strftime("%m/%d/%Y")}}</small></label>
+                <label class="bar-label" style="text-align: center">Abstracts Due:<br><small style="font-size:12px;" "text-align: center;">{{currentCycle.AllSubmissionsClosedDate.strftime("%m/%d/%Y")}} by 11:59PM</small></label>
             </div>
 {#            <div class="point" id="allsubmissionscloses">
                 <div class="bullet"></div>


### PR DESCRIPTION
The front page now displays "... by 11:59PM" on any closing due date. 

The database now stores 23:59 as the closing times, instead of 11:55AM. 