### PR TITLE
Fix devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,9 @@ ENV PYTHONUNBUFFERED=1
 RUN pip install --upgrade pip
 
 # Run source setup.sh whenever a bash terminal is opened in vscode (setup.sh is also run after volumes are mounted as the entrypoint in docker-compose)
-RUN echo "source setup.sh > /dev/null" > /home/vscode/.bashrc
+RUN echo "source setup.sh && clear" > /home/vscode/.bashrc
+# This copy line may or may not be necessary for the docker-compose entrypoint to work
+COPY entrypoint.sh /home/vscode/urcpp/entrypoint.sh 
+
 
 EXPOSE 8080

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,8 +8,7 @@ services:
     volumes:
       - ..:/home/vscode/urcpp
     
-    entrypoint: ["/home/vscode/urcpp/entrypoint.sh"]
-    command: sleep infinity
+    entrypoint: ["/bin/bash", "-c", "/home/vscode/urcpp/entrypoint.sh & sleep infinity"] # TODO: Replace sleep infinity with running the app maybe
 
     links:
       - db

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ..:/home/vscode/urcpp
     
-    entrypoint: ["/bin/bash", "-c", "/home/vscode/urcpp/entrypoint.sh & sleep infinity"] # TODO: Replace sleep infinity with running the app maybe
+    entrypoint: ["/bin/bash", "-c", "/home/vscode/urcpp/entrypoint.sh sleep infinity"]
 
     links:
       - db

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.py filter=gitignore
-entrypoint.sh text eol=lf
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.py filter=gitignore
+entrypoint.sh text eol=lf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ while [ ! -f /home/vscode/urcpp/setup.sh ]; do
     sleep 1
 done
 
-# Run the desired command
+# Run setup.sh
 cd /home/vscode/urcpp || { echo "Directory for project not found! Exiting."; exit 1; }
 ./setup.sh
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -e
 
-# Wait for the volume to be mounted
-while [ ! -f /home/vscode/urcpp/setup.sh ]; do
-    echo "Waiting for volume to be mounted..."
-    sleep 1
-done
-
 # Run setup.sh
 cd /home/vscode/urcpp || { echo "Directory for project not found! Exiting."; exit 1; }
 ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,7 @@
 if [ ! -d venv ]
 then
   python3 -m venv venv
+  chmod +x venv/bin/activate
 fi
 
 . venv/bin/activate

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,7 @@ if [ ! -d venv ]
 then
   python3 -m venv venv
   chmod +x venv/bin/activate
+  chown -R vscode:vscode venv
 fi
 
 . venv/bin/activate


### PR DESCRIPTION
Resolves issue #191:

The devcontainer was not initializing properly on windows machines due to improper line endings when git checks out .sh files on windows.

Solution:
I specified LF line endings for all .sh files in the .gitattributes file since the devcontainer always runs in a linux environment. 

I also cleaned up some unnecessary lines in the setup.sh file and made a couple QOL changes to the devcontainer.

To Test:
- Delete and freshly clone the urcpp repo.
- Open VSCode and reopen the application in a devcontainer
- Once, the application has finished its intialization in the docker container (could take awhile since we're initializing the venv), press any key to close the setup terminal
- Open a new terminal and type `python api.py` to run the application (There should be no need to activate the virtual environment manually)
- Assuming the application is up and running, open a web browser and navigate to `http://127.0.0.1:8080` and ensure you see the website up and running.